### PR TITLE
fix: deprecated $escape parameter default value in fputcsv()

### DIFF
--- a/Model/CsvWriter.php
+++ b/Model/CsvWriter.php
@@ -127,7 +127,7 @@ class CsvWriter
             $fields[$k] = $this->prepareFieldValue($f);
         }
 
-        if (false === fputcsv($this->outputFile, $fields, $this->delimiter)) {
+        if (false === fputcsv($this->outputFile, $fields, $this->delimiter, "\"", "")) {
             throw new FileSystemException(__("CsvWriter: failed to write row."));
         }
     }


### PR DESCRIPTION
Fixes error: Deprecated Functionality: fputcsv(): the $escape parameter must be provided as its default value will change. PHP 8.4 compatibility.